### PR TITLE
Fix systemd service

### DIFF
--- a/limitd.sh
+++ b/limitd.sh
@@ -11,17 +11,18 @@ if [ "$#" -ge  1 ]; then
 			echo $max | sudo tee /sys/class/power_supply/BAT?/charge_control_end_threshold > /dev/null
             cd /tmp
             echo "[Unit]
-            Description=To set battery charge threshold
-            After=multi-user.target
-            StartLimitBurst=0
+Description=To set battery charge threshold
+After=multi-user.target
+StartLimitBurst=0
 
-            [Service]
-            Type=oneshot
-            Restart=on-failure
-            ExecStart=/bin/bash -c 'echo $max > /sys/class/power_supply/BAT?/charge_control_end_threshold'
+[Service]
+Type=oneshot
+Restart=on-failure
+ExecStart=/bin/bash -c 'echo $max > /sys/class/power_supply/BAT?/charge_control_end_threshold'
 
-            [Install]
-            WantedBy=multi-user.target" > battery-manager.service
+[Install]
+WantedBy=multi-user.target
+" > battery-manager.service
 
             echo "created battery-manager.service `tput setaf 2`✓ `tput sgr0`"
 

--- a/limitd.sh
+++ b/limitd.sh
@@ -12,7 +12,7 @@ if [ "$#" -ge  1 ]; then
             cd /tmp
             echo "[Unit]
 Description=To set battery charge threshold
-After=multi-user.target
+After=multi-user.target suspend.target hibernate.target hybrid-sleep.target suspend-then-hibernate.target
 StartLimitBurst=0
 
 [Service]
@@ -21,7 +21,7 @@ Restart=on-failure
 ExecStart=/bin/bash -c 'echo $max > /sys/class/power_supply/BAT?/charge_control_end_threshold'
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target suspend.target hibernate.target hybrid-sleep.target suspend-then-hibernate.target
 " > battery-manager.service
 
             echo "created battery-manager.service `tput setaf 2`✓ `tput sgr0`"

--- a/limitd.sh
+++ b/limitd.sh
@@ -13,11 +13,9 @@ if [ "$#" -ge  1 ]; then
             echo "[Unit]
 Description=To set battery charge threshold
 After=multi-user.target suspend.target hibernate.target hybrid-sleep.target suspend-then-hibernate.target
-StartLimitBurst=0
 
 [Service]
 Type=oneshot
-Restart=on-failure
 ExecStart=/bin/bash -c 'echo $max > /sys/class/power_supply/BAT?/charge_control_end_threshold'
 
 [Install]

--- a/limitd.sh
+++ b/limitd.sh
@@ -18,7 +18,7 @@ if [ "$#" -ge  1 ]; then
             [Service]
             Type=oneshot
             Restart=on-failure
-            ExecStart=/bin/bash -c 'echo $max > /sys/class/power_supply/BAT0/charge_control_end_threshold'
+            ExecStart=/bin/bash -c 'echo $max > /sys/class/power_supply/BAT?/charge_control_end_threshold'
 
             [Install]
             WantedBy=multi-user.target" > battery-manager.service


### PR DESCRIPTION
- Now using a wildcard for the battery number in the path in the service's `ExecStart` command.
  - Previously, it was hard-coded to `0` but is different on some systems.
  - The service failed to start on systems where the number isn't `0` e.g mine.
- The service now runs when the system wakes up from sleep or hibernation.
- The formatting of the unit file is now correct, no more excess tabs.
- The service no longer restarts upon failure.
  - It's such a simple task that anything that causes it to fail the first time will also cause it to fail on subsequent runs.
