### PR TITLE
Update examples in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Note: make the scripts executable before running by executing
 
 -----
 >Tested with :
-> - Asus vivobook 15 with AMD Ryzen 3500U running Linux mint 20 Kernal 5.8.0-25-generic;
-> - Asus Vivobook 15 PRO OLED Ryzen5900 M3500 using 5.3.1 artix-linux;
+> - Asus vivobook 15 with AMD Ryzen 3500U running Linux mint 20 (Kernel: 5.8.0-25-generic);
+> - Asus Vivobook 15 PRO OLED Ryzen5900 M3500 using artix-linux (Kernel: 5.3.1);
 > - Asus TUF Gaming F15 using Debian 12;
+> - Asus ExpertBook B5 OLED B5302CEA using Fedora (Workstation Edition) 39 (Kernel: Linux 6.6.9-200.fc39.x86_64);


### PR DESCRIPTION
# Description of changes
Add Asus ExperBook B5;
Unify examples format in README.MD;

## Notes
1. Feel free to discard edits to other examples, as well as edit my contribution.

2. I've noticed that systemd script overrides the `limit.sh` setting. For example - I've set the limit to 80 using systemd script first. Later I thought that I'd like to test out it with a lower value first (I've had +- 70% charge), but despite putting 75-77%, my laptop charged up to 80%, and then stopped.

3. The `limit.sh` script doesn't ensure it has root user privileges. So, unlike systemd script, you have to run it with sudo/as a root user beforehand. (See picture below)

![image](https://github.com/sreejithag/battery-charging-limiter-linux/assets/146741211/1eaf80cc-52f4-4296-8402-6674e402cf8e)
